### PR TITLE
Fixed bug that caused slanted image. I think it is working correctly now

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,8 @@
 # Makefile
 # Boilerplate from: http://www.icosaedro.it/c-modules.html
 
+SHELL = /bin/bash
+
 # Compiler
 CC = gcc
 
@@ -32,3 +34,11 @@ clean:
 
 depend:
 	makedepend -Y -- $(CFLAGS) $(DEFS) -- *.c
+
+# Run this rule to convert the raw output into a bitmap and recompose it back into a single image
+# example:  make raw2bmp width=630 height=354
+raw2bmp:
+	convert -depth 8 -size $(width)x$(height) +flip gray:out_Y out_Y.bmp
+	convert -depth 8 -size $$(( $(width)/2 ))x$$(( $(height)/2 )) -sample $(width)x$(height) +flip gray:out_Cb out_Cb.bmp
+	convert -depth 8 -size $$(( $(width)/2 ))x$$(( $(height)/2 )) -sample $(width)x$(height) +flip gray:out_Cr out_Cr.bmp
+	convert out_Y.bmp out_Cb.bmp out_Cr.bmp -colorspace YCbCr -combine out_recomposed.bmp

--- a/rgb2ycbcr_basic.c
+++ b/rgb2ycbcr_basic.c
@@ -30,18 +30,18 @@ void rgb2ycbcr_basic(char * __restrict Y, char * __restrict Cb, char * __restric
       while(col < ncols) {
         unsigned char R_even, G_even, B_even, R_odd, G_odd, B_odd;
         float t_even, t_odd, t_Cb, t_Cr;
-        R_even = data[i_even++];
-        G_even = data[i_even++];
         B_even = data[i_even++];
+        G_even = data[i_even++];
+        R_even = data[i_even++];
         t_even = 16 + (R_TO_Y * R_even + G_TO_Y * G_even + B_TO_Y * B_even)/Y_NORM_FACTOR;
         Y[pixel_even] = (char) round(t_even > 255 ? 255 : t_even);
         t_Cb = (R_TO_CB * R_even + G_TO_CB * G_even + B_TO_CB * B_even);
         t_Cr = (R_TO_CR * R_even + G_TO_CR * G_even + B_TO_CR * B_even);
 
         // pixel 3
-        R_odd = data[i_odd++];
-        G_odd = data[i_odd++];
         B_odd = data[i_odd++];
+        G_odd = data[i_odd++];
+        R_odd = data[i_odd++];
         t_odd = 16 + (R_TO_Y * R_odd + G_TO_Y * G_odd + B_TO_Y * B_odd)/Y_NORM_FACTOR;
         Y[pixel_odd] = (char) round(t_even > 255 ? 255 : t_odd);
         t_Cb += (R_TO_CB * R_odd + G_TO_CB * G_odd + B_TO_CB * B_odd);
@@ -51,18 +51,18 @@ void rgb2ycbcr_basic(char * __restrict Y, char * __restrict Cb, char * __restric
         col++;
 
         // pixel 2
-        R_even = data[i_even++];
-        G_even = data[i_even++];
         B_even = data[i_even++];
+        G_even = data[i_even++];
+        R_even = data[i_even++];
         t_even = 16 + (R_TO_Y * R_even + G_TO_Y * G_even + B_TO_Y * B_even)/Y_NORM_FACTOR;
         Y[pixel_even] = (char) round(t_even > 255 ? 255 : t_even);
         t_Cb += (R_TO_CB * R_even + G_TO_CB * G_even + B_TO_CB * B_even);
         t_Cr += (R_TO_CR * R_even + G_TO_CR * G_even + B_TO_CR * B_even);
 
         // pixel 4
-        R_odd = data[i_odd++];
-        G_odd = data[i_odd++];
         B_odd = data[i_odd++];
+        G_odd = data[i_odd++];
+        R_odd = data[i_odd++];
         t_odd = 16 + (R_TO_Y * R_odd + G_TO_Y * G_odd + B_TO_Y * B_odd)/Y_NORM_FACTOR;
         Y[pixel_odd] = (char) round(t_odd > 255 ? 255 : t_odd);
         t_Cb += (R_TO_CB * R_odd + G_TO_CB * G_odd + B_TO_CB * B_odd);
@@ -111,12 +111,16 @@ int write_raw_image_data(char* filename, char* data, int size) {
 
 int main( int argc, char** argv) {
   printf("RGB to YCbCr: Simple Conversion\n");
+  bitmap_image* image;
+  if(argc==2) {
+    image = bmp_load(argv[1]);
+  } else {
+    printf("No input image specified");
+    return 0;
+  }
 
-  bitmap_image* image = bmp_load("./input/tiger.bmp");
-
-
-  unsigned int nrows = image->header.width;
-  unsigned int ncols = image->header.height;
+  unsigned int nrows = image->header.height;
+  unsigned int ncols = image->header.width;
   unsigned int npixels = nrows * ncols;
   char data2x4[32] = {
     0x20,0x30,0x40,0x20,0x30,0x40,0x00,0x00,


### PR DESCRIPTION
The slanted image was a stupid bug, i had mixed up nrows and ncols.

The program now reads the image as the first argument which makes it more flexible

I updated the makefile to perform the image conversion and recombining. Right now the image is a bit more faded but I think that is just due to the footroom and headroom (the YCbCr values range from 16-235 but the imagemagick conversion assumes 0-255 so the image has less contrast.

to run the conversion type: `make raw2bmp width=630 height=354`